### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ CheckoutPage:
         'summary': 'CheckoutStep_Summary'
 ```
 
+ * If included, remove SteppedCheckout::setupSteps() from your _config.php file (SteppedCheckout::setupSteps() creates default checkout page steps no longer needed with the above yaml entries).
+
  * To add the shipping estimation form to your CartPage template, add the following
  somewhere on your CartPage.ss template:
 


### PR DESCRIPTION
The inclusion of SteppedCheckout::setupSteps() in [mysite]_config.php overrides the Shipping Method of the Checkout Page (actually pushes it to the last entry in the array).  This can possibly occur if a developer has read the Silverstripe Shop's Multi-Step Checkout instructions first, before installing this module.
