### PR TITLE
Shipping address issue

### DIFF
--- a/code/model/ShippingMethod.php
+++ b/code/model/ShippingMethod.php
@@ -55,7 +55,7 @@ class ShippingCalculator{
 	function calculate($address = null) {
 		return $this->method->calculateRate(
 			$this->order->createShippingPackage(),
-			$address ? $address : $this->order->ShippingAddress()
+			$address ? $address : $this->order->getShippingAddress()
 		);
 	}
 


### PR DESCRIPTION

I have an ajax call, the call uses following code to get $shipping object:

$method = ShippingMethod::get()->filter(array("ID" => $id))->first();
$order = ShoppingCart::curr();
$shipping = $method->getCalculator($order)->calculate();

above was working with old burnbright/shop module, since the old module was no longer supported,
I have changed to use silvershop/core.

Now there is a problem,

for ShippingCalculator class, to get address, it uses following line:

$this->order->ShippingAddress()

I think it should change to getShippingAddress.
In older version of Order class, ShippingAddress is correct way to fetch address,