### PR TITLE
Set "silvershop/core" dependency requirement for both v1.0 and v2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
 		"installer-name": "silvershop-shipping"
 	},
 	"require": {
-		"silvershop/core": "~1.0",
+    "silvershop/core": "~1.0 || ~2.0",
 		"burnbright/silverstripe-shop-geocoding": "~1.2",
 		"silverstripe-australia/gridfieldextensions": "~1.0",
 		"burnbright/silverstripe-hasonefield": "dev-master"


### PR DESCRIPTION
Updated the SilverShop Core dependency so that v2.0 can be installed.