### PR TITLE
Added frontend translations.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,38 @@
+# Numerous always-ignore extensions
+*.diff
+*.err
+*.orig
+*.log
+*.rej
+*.swo
+*.swp
+*.vi
+*~
+*.sass-cache
+*.sql
+*.zip
+
+# OS or Editor folders
+.DS_Store
+.cache
+.project
+.settings
+.tmproj
+.idea
+nbproject
+Thumbs.db
+
+# Dreamweaver added files
+_notes
+dwsync.xml
+
+# Komodo
+*.komodoproject
+.komodotools
+
+# Folders to ignore
+.hg
+.svn
+.CVS
+intermediate
+publish

--- a/code/components/ShippingCheckoutComponent.php
+++ b/code/components/ShippingCheckoutComponent.php
@@ -12,7 +12,7 @@ class ShippingCheckoutComponent extends CheckoutComponent {
 		$fields->push(
 			OptionsetField::create(
 				"ShippingMethodID",
-				"Shipping Options",
+                _t('ShippingCheckoutComponent.ShippingOptions', 'Shipping Options'),
 				$estimates->map(),
 				$estimates->First()->ID
 			)
@@ -28,12 +28,18 @@ class ShippingCheckoutComponent extends CheckoutComponent {
 	public function validateData(Order $order, array $data) {
 		$result = new ValidationResult();
 		if(!isset($data['ShippingMethodID'])){
-			$result->error("Shipping method not provided", "ShippingMethod");
+			$result->error(
+                _t('ShippingCheckoutComponent.ShippingMethodNotProvidedMessage', "Shipping method not provided"),
+                _t('ShippingCheckoutComponent.ShippingMethodErrorCode', "ShippingMethod")
+            );
 			throw new ValidationException($result);
 		}
 
 		if(!ShippingMethod::get()->byID($data['ShippingMethodID'])){
-		 	$result->error("Shipping Method does not exist", "ShippingMethod");
+		 	$result->error(
+                _t('ShippingCheckoutComponent.ShippingMethodDoesNotExistMessage', "Shipping Method does not exist"),
+                _t('ShippingCheckoutComponent.ShippingMethodErrorCode', "ShippingMethod")
+            );
 		 	throw new ValidationException($result);
 		}
 	}

--- a/code/extensions/CheckoutStep_ShippingMethod.php
+++ b/code/extensions/CheckoutStep_ShippingMethod.php
@@ -31,7 +31,7 @@ class CheckoutStep_ShippingMethod extends CheckoutStep
 			$fields->push(
 				OptionsetField::create(
 					"ShippingMethodID",
-					"Shipping Options",
+                    _t('CheckoutStep_ShippingMethod.ShippingOptions', 'Shipping Options'),
 					$estimates->map(),
 					$estimates->First()->ID
 				)
@@ -40,9 +40,9 @@ class CheckoutStep_ShippingMethod extends CheckoutStep
 			$fields->push(
 				LiteralField::create(
 					"NoShippingMethods",
-					"<p class=\"message warning\">
-						There are no shipping methods available
-					</p>"
+                    _t('CheckoutStep_ShippingMethod.NoShippingMethods',
+                        '<p class=\"message warning\">There are no shipping methods available</p>'
+                    )
 				)
 			);
 		}

--- a/code/extensions/OrderShippingExtension.php
+++ b/code/extensions/OrderShippingExtension.php
@@ -61,13 +61,13 @@ class OrderShippingExtension extends DataExtension
 		$package = $this->owner->createShippingPackage();
 		if(!$package){
 			return $this->error(
-				_t("Checkout.NOPACKAGE", "Shipping package information not available")
+				_t("OrderShippingExtension.NoPackage", "Shipping package information not available")
 			);
 		}
 		$address = $this->owner->getShippingAddress();
 		if(!$address || !$address->exists()){
 			return $this->error(
-				_t("Checkout.NOADDRESS", "No address has been set")
+				_t("OrderShippingExtension.NoAddress", "No address has been set")
 			);
 		}
 		$this->owner->ShippingTotal = $option->calculateRate($package, $address);

--- a/code/forms/ShippingEstimateForm.php
+++ b/code/forms/ShippingEstimateForm.php
@@ -10,12 +10,15 @@ class ShippingEstimateForm extends Form
 		$address = new Address();  // get address to access it's getCountryField method
 		$fields = new FieldList(
 			$address->getCountryField(),
-			TextField::create('State', _t('Address.STATE', 'State')),
-			TextField::create('City', _t('Address.CITY', 'City')),
-			TextField::create('PostalCode', _t('Address.POSTALCODE', 'Postal Code'))
+			TextField::create('State', _t('Address.db_State', 'State')),
+			TextField::create('City', _t('Address.db_City', 'City')),
+			TextField::create('PostalCode', _t('Address.db_PostalCode', 'Postal Code'))
 		);
 		$actions =  new FieldList(
-			FormAction::create("submit", "Estimate")
+			FormAction::create(
+                "submit",
+                _t('ShippingEstimateForm.FormActionTitle', 'Estimate')
+            )
 		);
 		$validator = new RequiredFields(array(
 			'Country'
@@ -35,7 +38,10 @@ class ShippingEstimateForm extends Form
 			);
 			$estimates = $estimator->getEstimates();
 			if(!$estimates->exists()){
-				$form->sessionMessage("No estimates could be found for that location.","warning");
+				$form->sessionMessage(
+                    _t('ShippingEstimateForm.FormActionWarningMessage', 'No estimates could be found for that location.'),
+                    _t('ShippingEstimateForm.FormActionWarningCode', "warning")
+                );
 			}
 			Session::set("ShippingEstimates", $estimates);
 			if(Director::is_ajax()){

--- a/lang/en.yml
+++ b/lang/en.yml
@@ -1,0 +1,18 @@
+en:
+  ShippingCheckoutComponent:
+    ShippingOptions: 'Shipping Options'
+    ShippingMethodNotProvidedMessage: 'Shipping method not provided'
+    ShippingMethodDoesNotExistMessage: 'Shipping Method does not exist'
+    ShippingMethodErrorCode: 'ShippingMethod'
+  CheckoutStep_ShippingMethod:
+    ShippingOptions: 'Shipping Options'
+    NoShippingMethods: '<p class="message warning">There are no shipping methods available</p>'
+  OrderShippingExtension:
+    NoPackage: 'Shipping package information not available'
+    NoAddress: 'No address has been set'
+  ShippingEstimateForm:
+    FormActionTitle: 'Estimate'
+    FormActionWarningMessage: 'No estimates could be found for that location.'
+    FormActionWarningCode: 'warning'
+  ShippingFrameworkModifier:
+    SINGULARNAME: 'Shipping'

--- a/lang/nb.yml
+++ b/lang/nb.yml
@@ -1,0 +1,18 @@
+nb:
+  ShippingCheckoutComponent:
+    ShippingOptions: 'Fraktalternativ'
+    ShippingMethodNotProvidedMessage: 'Fraktalternativ er ikke oppgitt'
+    ShippingMethodDoesNotExistMessage: 'Fraktalternativ finnes ikke'
+    ShippingMethodErrorCode: 'ShippingMethod'
+  CheckoutStep_ShippingMethod:
+    ShippingOptions: 'Fraktalternativ'
+    NoShippingMethods: '<p class="message warning">Der er ingen Fraktalternativ tilgjengelig</p>'
+  OrderShippingExtension:
+    NoPackage: 'Informasjon om forsendelse er ikke tilgjengelig'
+    NoAddress: 'Adresse er ikke oppgitt'
+  ShippingEstimateForm:
+    FormActionTitle: 'Estimer'
+    FormActionWarningMessage: 'Kunne ikke beregne estimat for din lokasjon.'
+    FormActionWarningCode: 'warning'
+  ShippingFrameworkModifier:
+    SINGULARNAME: 'Frakt'

--- a/lang/nn.yml
+++ b/lang/nn.yml
@@ -1,0 +1,18 @@
+nn:
+  ShippingCheckoutComponent:
+    ShippingOptions: 'Sendingalternativ'
+    ShippingMethodNotProvidedMessage: 'Sendingalternativ er ikkje oppgitt'
+    ShippingMethodDoesNotExistMessage: 'Sendingalternativ finnes ikkje'
+    ShippingMethodErrorCode: 'ShippingMethod'
+  CheckoutStep_ShippingMethod:
+    ShippingOptions: 'Sendingalternativ'
+    NoShippingMethods: '<p class="message warning">Der er ingen sendingalternativ tilgjengelig</p>'
+  OrderShippingExtension:
+    NoPackage: 'Informasjon om sending er ikkje tilgjengeleg'
+    NoAddress: 'Adresse er ikke oppgitt'
+  ShippingEstimateForm:
+    FormActionTitle: 'Estimer'
+    FormActionWarningMessage: 'Kunne ikkje berekna estimat for din lokasjon.'
+    FormActionWarningCode: 'warning'
+  ShippingFrameworkModifier:
+    SINGULARNAME: 'Frakt'


### PR DESCRIPTION
Added en, nb and nn translations to the module frontend messages and fields.

Updated existing translations to point at SilverShop Core i18n such as: Address.CITY to Address.db_City. 

Rename Checkout.* (.NOADDRESS) to OrderShippingExtension.* (.NOADDRESS) as it did'nt exist in Core. It's easier to find translation origin when the class name is present in the key.

Added gitignore file.