### PR TITLE
Fixes BadMethodCallException issue

### DIFF
--- a/src/Model/Warehouse.php
+++ b/src/Model/Warehouse.php
@@ -17,7 +17,7 @@ class Warehouse extends DataObject
 
     private static $summary_fields = [
         'Title',
-        'Address'
+        'Address.Title' => 'Address'
     ];
 
     private static $table_name = 'SilverShop_Warehouse';


### PR DESCRIPTION
Error message: [Emergency] Uncaught BadMethodCallException: Object->__call(): the method 'scaffoldSearchField' does not exist on 'SilverShop\Model\Address'