### PR TITLE
Use order total instead of subtotal to calculate shipping

### DIFF
--- a/src/Extension/OrderShippingExtension.php
+++ b/src/Extension/OrderShippingExtension.php
@@ -35,7 +35,7 @@ class OrderShippingExtension extends DataExtension
             $height = $items->Sum('Height', true);
             $depth = $items->Sum('Depth', true);
 
-            $value = $this->owner->SubTotal();
+            $value = $this->owner->Total();
             $quantity = $items->Quantity();
 
             $package = ShippingPackage::create(


### PR DESCRIPTION
If used in conjunction with the discounts module, the Total should be used because it is the real price the customer pays, after discounts have been added.