### PR TITLE
Alternate fix for #61 that complies with #62

### DIFF
--- a/src/Checkout/Step/CheckoutStepShippingMethod.php
+++ b/src/Checkout/Step/CheckoutStepShippingMethod.php
@@ -74,7 +74,7 @@ class CheckoutStepShippingMethod extends CheckoutStep
             );
         }
 
-        $actions = new FieldList(            
+        $actions = new FieldList(
             new FormAction("setShippingMethod",  _t('SilverShop\Checkout\Step\CheckoutStep.Continue', 'Continue'))
         );
 
@@ -96,6 +96,10 @@ class CheckoutStepShippingMethod extends CheckoutStep
                 $order->setShippingMethod($option);
             }
         }
+
+        // perform write to store changes
+        $order->calculate();
+        $order->write();
 
         return $this->owner->redirect($this->NextStepLink());
     }

--- a/src/Extension/OrderShippingExtension.php
+++ b/src/Extension/OrderShippingExtension.php
@@ -19,6 +19,14 @@ class OrderShippingExtension extends DataExtension
         'ShippingMethod' => ShippingMethod::class
     ];
 
+    private static $casting = [
+        'TotalWithoutShipping' => 'Currency'
+    ];
+
+    public function TotalWithoutShipping(){
+        return $this->owner->Total() - $this->owner->ShippingTotal;
+    }
+
     public function createShippingPackage($value=0)
     {
         //create package, with total weight, dimensions, value, etc

--- a/src/Extension/OrderShippingExtension.php
+++ b/src/Extension/OrderShippingExtension.php
@@ -19,10 +19,10 @@ class OrderShippingExtension extends DataExtension
         'ShippingMethod' => ShippingMethod::class
     ];
 
-    public function createShippingPackage()
+    public function createShippingPackage($value=0)
     {
         //create package, with total weight, dimensions, value, etc
-        $weight = $width = $height = $depth = $value = $quantity = 0;
+        $weight = $width = $height = $depth = $quantity = 0;
 
         $items = $this->owner->Items();
 
@@ -35,7 +35,9 @@ class OrderShippingExtension extends DataExtension
             $height = $items->Sum('Height', true);
             $depth = $items->Sum('Depth', true);
 
-            $value = $this->owner->SubTotal();
+            if( !$value ) {
+                $value = $this->owner->SubTotal();
+            }
             $quantity = $items->Quantity();
 
             $package = ShippingPackage::create(

--- a/src/ShippingCalculator.php
+++ b/src/ShippingCalculator.php
@@ -19,10 +19,10 @@ class ShippingCalculator
         $this->order = $order;
     }
 
-    public function calculate($address = null)
+    public function calculate($address = null, $value=null)
     {
         return $this->method->calculateRate(
-            $this->order->createShippingPackage(),
+            $this->order->createShippingPackage($value),
             $address ? $address : $this->order->getShippingAddress()
         );
     }

--- a/src/ShippingEstimator.php
+++ b/src/ShippingEstimator.php
@@ -36,10 +36,12 @@ class ShippingEstimator
             return $this->estimates;
         }
 
+        $total = $this->order->TotalWithoutShipping();
+
         $output = new ArrayList();
         if ($options = $this->getShippingMethods()) {
             foreach ($options as $option) {
-                $rate = $option->getCalculator($this->order)->calculate($this->address);
+                $rate = $option->getCalculator($this->order)->calculate($this->address,$total);
                 if ($rate !== null) {
                     $option->CalculatedRate = $rate;
                     $output->push($option);

--- a/src/ShippingFrameworkModifier.php
+++ b/src/ShippingFrameworkModifier.php
@@ -12,7 +12,10 @@ class ShippingFrameworkModifier extends OrderModifier
     {
         $order = $this->Order();
         if ($order && $order->exists() && $shipping = $order->ShippingMethod()) {
-            return $shipping->getCalculator($order)->calculate(null,$incoming);
+            $value = $shipping->getCalculator($order)->calculate(null,$incoming);
+            $order->ShippingTotal = $value;
+            $order->write();
+            return $value;
         }
         return 0;
     }
@@ -29,4 +32,5 @@ class ShippingFrameworkModifier extends OrderModifier
 
         return $title;
     }
+
 }

--- a/src/ShippingFrameworkModifier.php
+++ b/src/ShippingFrameworkModifier.php
@@ -11,7 +11,7 @@ class ShippingFrameworkModifier extends OrderModifier
     public function value($incoming)
     {
         $order = $this->Order();
-        if ($order && $order->exists() && $shipping = $order->ShippingMethod()) {
+        if ($order && $order->exists() && ($shipping = $order->ShippingMethod()) && $shipping->exists() ) {
             $value = $shipping->getCalculator($order)->calculate(null,$incoming);
             $order->ShippingTotal = $value;
             $order->write();

--- a/src/ShippingFrameworkModifier.php
+++ b/src/ShippingFrameworkModifier.php
@@ -12,7 +12,7 @@ class ShippingFrameworkModifier extends OrderModifier
     {
         $order = $this->Order();
         if ($order && $order->exists() && $shipping = $order->ShippingMethod()) {
-            return $shipping->getCalculator($order)->calculate();
+            return $shipping->getCalculator($order)->calculate(null,$incoming);
         }
         return 0;
     }


### PR DESCRIPTION
Issues: #62 #61

Instead of using the Order Total in the Shipping Package we supply the running total to the shipping modifier, during the calculation process. This way we make sure that discounts are taken into account, without altering the total of the Order.

Added method TotalWithoutShipping to OrderShippingExtension, so we can calculate the right shipping estimates with the calculated Total minus ShippingTotal. This ensures that the estimates also take discounts into account.

