### PR TITLE
Show the currency symbol in shipping option labels of the step checkout

### DIFF
--- a/src/Checkout/Step/CheckoutStepShippingMethod.php
+++ b/src/Checkout/Step/CheckoutStepShippingMethod.php
@@ -55,17 +55,11 @@ class CheckoutStepShippingMethod extends CheckoutStep
                 $order->setShippingMethod($estimates->First());
             }
 
-            // style label
-            $labels = [];
-            foreach ($estimates as $estimate) {
-                $labels[$estimate->ID] = $estimate->getTitle();
-            }
-            
             $fields->push(
                 OptionsetField::create(
                     "ShippingMethodID",
                     _t('CheckoutStep_ShippingMethod.ShippingOptions', 'Shipping Options'),
-                    $labels,
+                    $estimates->map('ID', 'getTitle'),
                     $estimates->First()->ID
                 )
             );
@@ -102,7 +96,7 @@ class CheckoutStepShippingMethod extends CheckoutStep
                 $order->setShippingMethod($option);
             }
         }
-        
+
         $this->owner->extend('onSetShippingMethod', $order, $data, $form);
 
         // perform write to store changes

--- a/src/Checkout/Step/CheckoutStepShippingMethod.php
+++ b/src/Checkout/Step/CheckoutStepShippingMethod.php
@@ -55,11 +55,17 @@ class CheckoutStepShippingMethod extends CheckoutStep
                 $order->setShippingMethod($estimates->First());
             }
 
+            // style label
+            $labels = [];
+            foreach ($estimates as $estimate) {
+                $labels[$estimate->ID] = $estimate->getTitle();
+            }
+            
             $fields->push(
                 OptionsetField::create(
                     "ShippingMethodID",
                     _t('CheckoutStep_ShippingMethod.ShippingOptions', 'Shipping Options'),
-                    $estimates->map(),
+                    $labels,
                     $estimates->First()->ID
                 )
             );

--- a/src/Model/ShippingMethod.php
+++ b/src/Model/ShippingMethod.php
@@ -4,6 +4,7 @@ namespace SilverShop\Shipping\Model;
 
 use SilverStripe\ORM\DataObject;
 use SilverShop\Model\Order;
+use SilverShop\ORM\FieldType\ShopCurrency;
 use SilverShop\Shipping\ShippingPackage;
 use SilverShop\Model\Address;
 use SilverShop\Shipping\ShippingCalculator;
@@ -47,8 +48,21 @@ class ShippingMethod extends DataObject
 
     public function getTitle()
     {
-        $title = implode(" - ", array_filter([
+        $rate = number_format(
             $this->Rate,
+            2,
+            ShopCurrency::config()->decimal_delimiter,
+            ShopCurrency::config()->thousand_delimiter
+        );
+
+        if (ShopCurrency::config()->append_symbol) {
+            $rate = $rate . ' ' . ShopCurrency::config()->currency_symbol;
+        } else {
+            $rate = ShopCurrency::config()->currency_symbol . $rate;
+        }
+
+        $title = implode(" - ", array_filter([
+            $rate,
             $this->Name,
             $this->Description
         ]));


### PR DESCRIPTION
Recommending the addition of the currency symbol in the shipping option labels.  This will make the presentation consistent with how shipping costs are shown in the cart.    