### PR TITLE
Fixes #80 - correctly use Product fields for ShippingPackage calculations

### DIFF
--- a/src/Extension/OrderShippingExtension.php
+++ b/src/Extension/OrderShippingExtension.php
@@ -46,10 +46,10 @@ class OrderShippingExtension extends Extension
         if (!$items->exists()) {
             $package = ShippingPackage::create();
         } else {
-            $weight = $items->Sum('Weight'); //Sum is found on OrdItemList (Component Extension)
-            $width = $items->Sum('Width');
-            $height = $items->Sum('Height');
-            $depth = $items->Sum('Depth');
+            $weight = $items->Sum('Weight', true); //Sum is found on OrderItemList (Component Extension)
+            $width = $items->Sum('Width', true);
+            $height = $items->Sum('Height', true);
+            $depth = $items->Sum('Depth', true);
 
             if ($value == 0) {
                 $value = $this->owner->SubTotal();


### PR DESCRIPTION
Fixes #80 - restore $onproduct=true parameter to use Product fields for ShippingPackage calculations